### PR TITLE
Return the new pickOffset value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gl-scatter2d",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "2D WebGL scatter plots",
   "main": "scatter2d.js",
   "directories": {

--- a/scatter2d.js
+++ b/scatter2d.js
@@ -202,6 +202,8 @@ proto.draw = function(pickOffset) {
       shader.uniforms.useWeight = 0
     }
   }
+
+  return pickOffset + this.pointCount
 }
 
 proto.drawPick = proto.draw


### PR DESCRIPTION
Fixing the issue with no pickOffset returned when multiple traces are present.