### PR TITLE
Unsnap points

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Creates a new 2D scatter plot.
 
 `options` has the following properties:
 
-* `data` is a packed 2*n length array of the unrolled xy coordinates of the points (required)
+* `positions` is a packed 2*n length array of the unrolled xy coordinates of the points (required)
 * `size` is a number giving the diameter of a marker in pixels (default `12`)
 * `color` is the color of a marker as a length 4 RGBA array (default `[1,0,0,1]`)
 * `borderSize` is the width of the border around each point in pixels (default `1`)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Creates a new 2D scatter plot.
 * `color` is the color of a marker as a length 4 RGBA array (default `[1,0,0,1]`)
 * `borderSize` is the width of the border around each point in pixels (default `1`)
 * `borderColor` is the color of the border of each point (default `[0,0,0,1]`)
+* `snapPoints` defines whether points should be grouped hierarchically to optimize rendering of huge number of points
 
 **Returns** A new scatter plot object, which is also registered to `plot`
 

--- a/example/566.js
+++ b/example/566.js
@@ -1,0 +1,23 @@
+/**
+ * plotly.js #566 case
+ */
+
+const setup = require('./')
+
+let N = 1e3
+
+let positions = Array(N*2).fill(0).map((v, i) => (Math.random() * 10 - 5) )
+let sizes = Array(N).fill(0).map(v => 10)
+let colors = Array(N*4).fill(0).map((v, i) => !((i + 1) % 4) ? .7 : Math.random())
+let glyphs = Array(N).fill('●')
+let borderWidths = Array(N).fill(.5)
+let borderColors = Array(N*4).fill(0).map((v, i) => !((i+1) % 4) ? .7 : 1)
+
+setup({
+  positions,
+  sizes,
+  colors,
+  glyphs,
+  borderColors,
+  borderWidths
+})

--- a/example/index.js
+++ b/example/index.js
@@ -1,0 +1,161 @@
+/**
+ * Create gl-scatter2d-fancy test-case
+ */
+
+var fit = require('canvas-fit')
+var mouseWheel = require('mouse-wheel')
+var mouseChange = require('mouse-change')
+var createScatter = require('../')
+var createSelectBox = require('gl-select-box')
+var createSpikes = require('gl-spikes2d')
+var createPlot = require('gl-plot2d')
+var createFps = require('fps-indicator')
+
+
+module.exports = setup;
+
+
+function setup (options) {
+  createFps()
+
+  var canvas = document.createElement('canvas')
+  document.body.appendChild(canvas)
+  window.addEventListener('resize', fit(canvas, null, +window.devicePixelRatio), false)
+
+  var gl = canvas.getContext('webgl', {
+    depth: false,
+    // alpha: true,
+    // premultipliedAlpha: true
+  })
+
+  var aspect = gl.drawingBufferWidth / gl.drawingBufferHeight
+  var dataBox = [-10,-10/aspect,10,10/aspect]
+
+  function makeTicks(lo, hi) {
+    var result = []
+    for(var i=lo; i<=hi; ++i) {
+      result.push({
+        x: i,
+        text: i + ''
+      })
+    }
+    return result
+  }
+
+  var plot = createPlot({
+    gl:             gl,
+    dataBox:        dataBox,
+    title:          'gl-scatter2d',
+    ticks:          [ makeTicks(-20,20), makeTicks(-20,20) ],
+    labels:         ['x', 'y'],
+    pixelRatio:     1,
+    tickMarkWidth:  [1,1,1,1],
+    tickMarkLength: [3,3,3,3]
+  })
+
+
+
+  var selectBox = createSelectBox(plot, {
+    innerFill: false,
+    outerFill: true
+  })
+  selectBox.enabled = false
+
+  var spikes = createSpikes(plot)
+
+  var scatter = createScatter(plot, options)
+
+
+  var lastX = 0, lastY = 0
+  var boxStart = [0,0]
+  var boxEnd   = [0,0]
+  var boxEnabled = false
+  mouseChange(function(buttons, x, y, mods) {
+    y = window.innerHeight - y
+    x *= plot.pixelRatio
+    y *= plot.pixelRatio
+
+    if(buttons & 1) {
+      if(mods.shift) {
+        var dataX = (x - plot.viewBox[0]) / (plot.viewBox[2]-plot.viewBox[0]) * (dataBox[2] - dataBox[0]) + dataBox[0]
+        var dataY = (y - plot.viewBox[1]) / (plot.viewBox[3]-plot.viewBox[1]) * (dataBox[3] - dataBox[1]) + dataBox[1]
+        if(!boxEnabled) {
+          boxStart[0] = dataX
+          boxStart[1] = dataY
+        }
+        boxEnd[0] = dataX
+        boxEnd[1] = dataY
+        boxEnabled = true
+        spikes.update()
+      } else {
+        var dx = (lastX - x) * (dataBox[2] - dataBox[0]) / (plot.viewBox[2]-plot.viewBox[0])
+        var dy = (lastY - y) * (dataBox[3] - dataBox[1]) / (plot.viewBox[3] - plot.viewBox[1])
+
+        dataBox[0] += dx
+        dataBox[1] += dy
+        dataBox[2] += dx
+        dataBox[3] += dy
+
+        plot.setDataBox(dataBox)
+        spikes.update()
+      }
+    } else {
+      var result = plot.pick(x/plot.pixelRatio, y/plot.pixelRatio)
+      if(result) {
+        spikes.update({center: result.dataCoord})
+      } else {
+        spikes.update()
+      }
+    }
+
+    if(boxEnabled) {
+      selectBox.enabled = true
+      selectBox.selectBox = [
+        Math.min(boxStart[0], boxEnd[0]),
+        Math.min(boxStart[1], boxEnd[1]),
+        Math.max(boxStart[0], boxEnd[0]),
+        Math.max(boxStart[1], boxEnd[1])
+      ]
+      plot.setDirty()
+      if(!((buttons&1) && mods.shift)) {
+        selectBox.enabled = false
+        dataBox = [
+          Math.min(boxStart[0], boxEnd[0]),
+          Math.min(boxStart[1], boxEnd[1]),
+          Math.max(boxStart[0], boxEnd[0]),
+          Math.max(boxStart[1], boxEnd[1])
+        ]
+        plot.setDataBox(dataBox)
+        boxEnabled = false
+      }
+    }
+
+    lastX = x
+    lastY = y
+  })
+
+  mouseWheel(function(dx, dy, dz) {
+    var scale = Math.exp(0.1 * dy / gl.drawingBufferHeight)
+
+    var cx = (lastX - plot.viewBox[0]) / (plot.viewBox[2] - plot.viewBox[0]) * (dataBox[2] - dataBox[0]) + dataBox[0]
+    var cy = (plot.viewBox[1] - lastY) / (plot.viewBox[3] - plot.viewBox[1]) * (dataBox[3] - dataBox[1]) + dataBox[3]
+
+    dataBox[0] = (dataBox[0] - cx) * scale + cx
+    dataBox[1] = (dataBox[1] - cy) * scale + cy
+    dataBox[2] = (dataBox[2] - cx) * scale + cx
+    dataBox[3] = (dataBox[3] - cy) * scale + cy
+
+    plot.setDataBox(dataBox)
+
+    return true
+  })
+
+  function render() {
+    requestAnimationFrame(render)
+    plot.draw()
+  }
+
+  render()
+
+  return scatter
+}

--- a/example/points.js
+++ b/example/points.js
@@ -1,0 +1,26 @@
+/**
+ * Test multiple points
+ */
+require('enable-mobile')
+const setup = require('./')
+
+
+//5e6 is allocation maximum
+// var POINT_COUNT = 3e6
+var POINT_COUNT = 1e7
+
+var positions = new Float32Array(2 * POINT_COUNT)
+for(var i=0; i<2*POINT_COUNT; ++i) {
+  positions[i] = Math.random() * 10 - 5
+}
+
+
+
+setup({
+  positions:  positions,
+  size:      5,
+  color:     [0,0,0,1],
+  borderSize: 1,
+  borderColor: [.5,.5,.5,.5]
+})
+

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     ]
   },
   "dependencies": {
+    "array-normalize": "^1.1.0",
     "binary-search-bounds": "^2.0.3",
     "gl-buffer": "^2.1.2",
     "gl-shader": "^4.0.4",
@@ -20,10 +21,16 @@
     "typedarray-pool": "^1.1.0"
   },
   "devDependencies": {
-    "mouse-change": "^1.2.1",
-    "mouse-wheel": "^1.0.2",
+    "array-bounds": "^1.0.0",
+    "canvas-fit": "^1.5.0",
+    "enable-mobile": "^1.0.7",
+    "fps-indicator": "^1.0.2",
     "gauss-random": "^1.0.1",
-    "canvas-fit": "^1.4.0"
+    "gl-plot2d": "^1.2.0",
+    "gl-select-box": "^1.0.1",
+    "gl-spikes2d": "^1.0.1",
+    "mouse-change": "^1.4.0",
+    "mouse-wheel": "^1.2.0"
   },
   "scripts": {
     "test": "tape test/*.js"
@@ -39,7 +46,10 @@
     "2d"
   ],
   "author": "Mikola Lysenko",
-  "contributors": ["Étienne Tétreault-Pinard", "Robert Monfera"],
+  "contributors": [
+    "Étienne Tétreault-Pinard",
+    "Robert Monfera"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/gl-vis/gl-scatter2d/issues"


### PR DESCRIPTION
Adds `snapPoints` option, providing direct points draw without recalculating hierarchical cache.
Also adds a couple of useful examples.
Related to https://github.com/plotly/plotly.js/pull/1657