### PR TITLE
Gate clearing x-coords pool

### DIFF
--- a/example/points.js
+++ b/example/points.js
@@ -11,7 +11,7 @@ var POINT_COUNT = 1e6
 
 var positions = new Float32Array(2 * POINT_COUNT)
 for(var i=0; i<2*POINT_COUNT; ++i) {
-  positions[i] = Math.random() * 10 - 5
+  positions[i] = random() * 10
 }
 
 

--- a/scatter2d.js
+++ b/scatter2d.js
@@ -62,10 +62,10 @@ proto.update = function(options) {
   this.borderColor  = dflt('borderColor', [0, 0, 0, 1]).slice()
   this.snapPoints   = dflt('snapPoints', true)
 
-  if(this.xCoords) pool.free(this.xCoords)
-
   //do not recalc points if there is no positions
   if (options.positions != null) {
+    if(this.xCoords) pool.free(this.xCoords)
+
     this.points             = options.positions
     var pointCount          = this.points.length >>> 1
 


### PR DESCRIPTION
That affects https://github.com/plotly/plotly.js/pull/1657
Now if you select points and zoom in, plot loses points.
This PR fixes that @etpinard 