### PR TITLE
Prevent canvas from moving up/down upon interactions

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -20,6 +20,7 @@ function setup (options) {
 
   var canvas = document.createElement('canvas')
   document.body.appendChild(canvas)
+  document.body.style.overflow = 'hidden'
   window.addEventListener('resize', fit(canvas, null, +window.devicePixelRatio), false)
 
   var gl = canvas.getContext('webgl', {


### PR DESCRIPTION
this just makes it simpler to gauge interaction speed as the canvas won't move around when eg. wheel zooming